### PR TITLE
fix: support umbrella chart global values for sandbox

### DIFF
--- a/deploy/helm/sandbox/templates/_helpers.tpl
+++ b/deploy/helm/sandbox/templates/_helpers.tpl
@@ -88,9 +88,114 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Get the ingress class name from depServices
 */}}
 {{- define "sandbox.ingressClass" -}}
-{{- if and .Values.depServices (index .Values.depServices "class-443") (index .Values.depServices "class-443").ingressClass -}}
-{{- (index .Values.depServices "class-443").ingressClass -}}
+{{- $depServices := mergeOverwrite (deepCopy (default dict .Values.depServices)) (default dict .Values.global.depServices) -}}
+{{- if and $depServices (index $depServices "class-443") (index $depServices "class-443").ingressClass -}}
+{{- (index $depServices "class-443").ingressClass -}}
 {{- else -}}
 {{- "nginx" -}}
 {{- end -}}
 {{- end }}
+
+
+{{/* ========== Universal Global Values Merge Helpers ========== */}}
+{{/* All charts use these same helper function names for consistency */}}
+
+{{- define "mergedGlobalValues.imageRegistry" -}}
+{{- $globalImage := (.Values.global | default dict).image | default dict -}}
+{{- if $globalImage.registry -}}
+{{- $globalImage.registry -}}
+{{- else -}}
+{{- .Values.image.registry -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.replicaCount" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "replicaCount" -}}
+{{- $global.replicaCount -}}
+{{- else -}}
+{{- .Values.replicaCount -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.env" -}}
+{{- $globalEnv := (.Values.global | default dict).env | default dict -}}
+{{- if $globalEnv -}}
+{{- toYaml (mergeOverwrite (deepCopy (.Values.env | default dict)) $globalEnv) -}}
+{{- else -}}
+{{- toYaml .Values.env -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.depServices" -}}
+{{- $globalDeps := (.Values.global | default dict).depServices | default dict -}}
+{{- if $globalDeps -}}
+{{- toYaml (mergeOverwrite (deepCopy (.Values.depServices | default dict)) $globalDeps) -}}
+{{- else -}}
+{{- toYaml .Values.depServices -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.imagePullSecrets" -}}
+{{- $localSecrets := .Values.imagePullSecrets | default (list) -}}
+{{- $globalSecrets := (.Values.global | default dict).imagePullSecrets | default (list) -}}
+{{- if gt (len $localSecrets) 0 -}}
+{{- toYaml $localSecrets -}}
+{{- else if gt (len $globalSecrets) 0 -}}
+{{- toYaml $globalSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.namespace" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "namespace" -}}
+{{- $global.namespace -}}
+{{- else -}}
+{{- .Values.namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.mode" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "mode" -}}
+{{- $global.mode -}}
+{{- else -}}
+{{- .Values.mode | default "Community" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.accessAddress" -}}
+{{- $globalAccess := (.Values.global | default dict).accessAddress | default dict -}}
+{{- if $globalAccess -}}
+{{- toYaml (mergeOverwrite (deepCopy (.Values.accessAddress | default dict)) $globalAccess) -}}
+{{- else -}}
+{{- toYaml .Values.accessAddress -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.ingressClassName" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "ingressClassName" -}}
+{{- $global.ingressClassName -}}
+{{- else -}}
+{{- .Values.ingressClassName | default "nginx" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.flowAutomation" -}}
+{{- $globalFlow := (.Values.global | default dict).flowAutomation | default dict -}}
+{{- if $globalFlow -}}
+{{- toYaml (mergeOverwrite (deepCopy (.Values.flowAutomation | default dict)) $globalFlow) -}}
+{{- else -}}
+{{- toYaml .Values.flowAutomation -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.image" -}}
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
+{{- if $imageRegistry }}
+{{- printf "%s/%s:%s" $imageRegistry .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/sandbox/templates/configmap.yaml
+++ b/deploy/helm/sandbox/templates/configmap.yaml
@@ -1,17 +1,21 @@
 {{- if .Values.configMap.create }}
 ---
+{{- $env := include "mergedGlobalValues.env" . | fromYaml -}}
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
+{{- $accessAddress := include "mergedGlobalValues.accessAddress" . | fromYaml -}}
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.configMap.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
 data:
   ENVIRONMENT: {{ .Values.controlPlane.env.ENVIRONMENT | quote }}
   DEBUG: {{ .Values.controlPlane.env.DEBUG | quote }}
   DATABASE_URL: {{ .Values.controlPlane.env.DATABASE_URL | quote }}
-  KUBERNETES_NAMESPACE: {{ .Values.namespace | quote }}
+  KUBERNETES_NAMESPACE: {{ .Release.Namespace | quote }}
   DEFAULT_TIMEOUT: {{ .Values.controlPlane.env.DEFAULT_TIMEOUT | quote }}
   MAX_TIMEOUT: {{ .Values.controlPlane.env.MAX_TIMEOUT | quote }}
   DEFAULT_CPU: {{ .Values.controlPlane.env.DEFAULT_CPU | quote }}
@@ -22,23 +26,23 @@ data:
   CLEANUP_INTERVAL_SECONDS: {{ .Values.controlPlane.env.CLEANUP_INTERVAL_SECONDS | quote }}
   DISABLE_BWRAP: {{ .Values.controlPlane.env.DISABLE_BWRAP | quote }}
   PYTHONUNBUFFERED: {{ .Values.controlPlane.env.PYTHONUNBUFFERED | quote }}
-  DEFAULT_TEMPLATE_IMAGE: "{{- if .Values.controlPlane.defaultTemplate.image.registry }}{{ .Values.controlPlane.defaultTemplate.image.registry }}/{{ else if .Values.image.registry }}{{ .Values.image.registry }}/{{ end }}{{ .Values.controlPlane.defaultTemplate.image.repository }}:{{ .Values.controlPlane.defaultTemplate.image.tag }}"
-  CONTROL_PLANE_URL: "http://{{ include "sandbox.controlPlaneName" . }}.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.controlPlane.service.port }}"
+  DEFAULT_TEMPLATE_IMAGE: "{{- if .Values.controlPlane.defaultTemplate.image.registry }}{{ .Values.controlPlane.defaultTemplate.image.registry }}/{{ else if $imageRegistry }}{{ $imageRegistry }}/{{ end }}{{ .Values.controlPlane.defaultTemplate.image.repository }}:{{ .Values.controlPlane.defaultTemplate.image.tag }}"
+  CONTROL_PLANE_URL: "http://{{ include "sandbox.controlPlaneName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.controlPlane.service.port }}"
   # Database connection from depServices.rds
-  {{- if .Values.depServices.rds }}
-  DB_TYPE: {{ .Values.depServices.rds.type | quote }}
-  DB_HOST: {{ .Values.depServices.rds.host | quote }}
-  DB_PORT: {{ .Values.depServices.rds.port | quote }}
-  DB_HOST_READ: {{ .Values.depServices.rds.hostRead | quote }}
-  DB_PORT_READ: {{ .Values.depServices.rds.portRead | quote }}
-  DB_USER: {{ .Values.depServices.rds.user | quote }}
-  DB_PASSWORD: {{ .Values.depServices.rds.password | quote }}
-  DB_DATABASE: {{ .Values.depServices.rds.database | quote }}
-  DB_MAX_CONNECTIONS: {{ .Values.depServices.rds.maxConnections | quote }}
-  DB_MAX_READ_CONNECTIONS: {{ .Values.depServices.rds.maxReadConnections | quote }}
-  DB_CHARSET: {{ .Values.depServices.rds.dbCharset | quote }}
-  DB_TIMEOUT: {{ .Values.depServices.rds.timeout | quote }}
-  DB_READ_TIMEOUT: {{ .Values.depServices.rds.readTimeout | quote }}
-  DB_WRITE_TIMEOUT: {{ .Values.depServices.rds.writeTimeout | quote }}
+  {{- if $depServices.rds }}
+  DB_TYPE: {{ $depServices.rds.type | quote }}
+  DB_HOST: {{ $depServices.rds.host | quote }}
+  DB_PORT: {{ $depServices.rds.port | quote }}
+  DB_HOST_READ: {{ $depServices.rds.hostRead | quote }}
+  DB_PORT_READ: {{ $depServices.rds.portRead | quote }}
+  DB_USER: {{ $depServices.rds.user | quote }}
+  DB_PASSWORD: {{ $depServices.rds.password | quote }}
+  DB_DATABASE: {{ $depServices.rds.database | quote }}
+  DB_MAX_CONNECTIONS: {{ $depServices.rds.maxConnections | quote }}
+  DB_MAX_READ_CONNECTIONS: {{ $depServices.rds.maxReadConnections | quote }}
+  DB_CHARSET: {{ $depServices.rds.dbCharset | quote }}
+  DB_TIMEOUT: {{ $depServices.rds.timeout | quote }}
+  DB_READ_TIMEOUT: {{ $depServices.rds.readTimeout | quote }}
+  DB_WRITE_TIMEOUT: {{ $depServices.rds.writeTimeout | quote }}
   {{- end }}
 {{- end }}

--- a/deploy/helm/sandbox/templates/control-plane-deployment.yaml
+++ b/deploy/helm/sandbox/templates/control-plane-deployment.yaml
@@ -1,10 +1,12 @@
 {{- if .Values.controlPlane.enabled }}
 ---
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "sandbox.controlPlaneName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: control-plane
@@ -29,7 +31,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "sandbox.controlPlaneName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: control-plane
@@ -38,7 +40,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: {{ index .Values.depServices "class-443" "ingressClass" | default "nginx" }}
+  ingressClassName: {{ index $depServices "class-443" "ingressClass" | default "nginx" }}
   rules:
   - http:
       paths:
@@ -58,7 +60,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "sandbox.controlPlaneName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: control-plane
@@ -91,14 +93,14 @@ spec:
       #       - sh
       #       - -c
       #       - |
-      #         until nc -z mariadb.{{ .Values.namespace }}.svc.cluster.local 3306; do
+      #         until nc -z mariadb.{{ .Release.Namespace }}.svc.cluster.local 3306; do
       #           echo "Waiting for MariaDB..."
       #           sleep 2
       #         done
       #         echo "MariaDB is ready!"
       containers:
         - name: control-plane
-          image: "{{- if .Values.controlPlane.image.registry }}{{ .Values.controlPlane.image.registry }}/{{ else if .Values.image.registry }}{{ .Values.image.registry }}/{{ end }}{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag }}"
+          image: "{{- if .Values.controlPlane.image.registry }}{{ .Values.controlPlane.image.registry }}/{{ else if $imageRegistry }}{{ $imageRegistry }}/{{ end }}{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag }}"
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
           ports:
             - name: http
@@ -285,7 +287,7 @@ spec:
                   key: S3_REGION
             # Internal configuration
             - name: CONTROL_PLANE_URL
-              value: "http://{{ include "sandbox.controlPlaneName" . }}.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.controlPlane.service.port }}"
+              value: "http://{{ include "sandbox.controlPlaneName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.controlPlane.service.port }}"
           resources:
             {{- toYaml .Values.controlPlane.resources | nindent 12 }}
           livenessProbe:

--- a/deploy/helm/sandbox/templates/mariadb-deployment.yaml
+++ b/deploy/helm/sandbox/templates/mariadb-deployment.yaml
@@ -1,10 +1,11 @@
 {{- if .Values.mariadb.enabled }}
 ---
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: mariadb-pv
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: mariadb
@@ -23,7 +24,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: mariadb
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: mariadb
@@ -41,7 +42,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mariadb
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: mariadb
@@ -59,7 +60,7 @@ spec:
     spec:
       containers:
         - name: mariadb
-          image: "{{- if .Values.mariadb.image.registry }}{{ .Values.mariadb.image.registry }}/{{ else if .Values.image.registry }}{{ .Values.image.registry }}/{{ end }}{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}"
+          image: "{{- if .Values.mariadb.image.registry }}{{ .Values.mariadb.image.registry }}/{{ else if $imageRegistry }}{{ $imageRegistry }}/{{ end }}{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}"
           imagePullPolicy: {{ .Values.mariadb.image.pullPolicy }}
           ports:
             - name: mysql
@@ -99,7 +100,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: mariadb
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: mariadb

--- a/deploy/helm/sandbox/templates/minio-deployment.yaml
+++ b/deploy/helm/sandbox/templates/minio-deployment.yaml
@@ -1,10 +1,11 @@
 {{- if .Values.minio.enabled }}
 ---
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: minio-pv
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: minio
@@ -23,7 +24,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: minio
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: minio
@@ -41,7 +42,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: minio
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: minio
@@ -59,7 +60,7 @@ spec:
     spec:
       containers:
         - name: minio
-          image: "{{- if .Values.minio.image.registry }}{{ .Values.minio.image.registry }}/{{ else if .Values.image.registry }}{{ .Values.image.registry }}/{{ end }}{{ .Values.minio.image.repository }}:{{ .Values.minio.image.tag }}"
+          image: "{{- if .Values.minio.image.registry }}{{ .Values.minio.image.registry }}/{{ else if $imageRegistry }}{{ $imageRegistry }}/{{ end }}{{ .Values.minio.image.repository }}:{{ .Values.minio.image.tag }}"
           imagePullPolicy: {{ .Values.minio.image.pullPolicy }}
           args:
             - server
@@ -103,7 +104,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: minio
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: minio

--- a/deploy/helm/sandbox/templates/rbac.yaml
+++ b/deploy/helm/sandbox/templates/rbac.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "sandbox.rbacName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: control-plane
@@ -30,7 +30,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "sandbox.rbacName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: control-plane
@@ -41,5 +41,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "sandbox.serviceAccountName" . }}
-    namespace: {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/deploy/helm/sandbox/templates/s3fs-secret.yaml
+++ b/deploy/helm/sandbox/templates/s3fs-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: s3fs-passwd
-  namespace: {{ .Values.namespace | default "sandbox-system" }}
+  namespace: {{ .Release.Namespace | default "sandbox-system" }}
 type: Opaque
 stringData:
   s3fs-passwd: |

--- a/deploy/helm/sandbox/templates/secret.yaml
+++ b/deploy/helm/sandbox/templates/secret.yaml
@@ -4,12 +4,12 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.secret.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
 type: Opaque
 stringData:
-  S3_ENDPOINT_URL: {{ printf "http://minio.%s.svc.cluster.local:9000" .Values.namespace | quote }}
+  S3_ENDPOINT_URL: {{ printf "http://minio.%s.svc.cluster.local:9000" .Release.Namespace | quote }}
   S3_ACCESS_KEY_ID: {{ .Values.secret.s3.accessKeyId | quote }}
   S3_SECRET_ACCESS_KEY: {{ .Values.secret.s3.secretAccessKey | quote }}
   S3_BUCKET: {{ .Values.controlPlane.s3.bucket | quote }}

--- a/deploy/helm/sandbox/templates/serviceaccount.yaml
+++ b/deploy/helm/sandbox/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "sandbox.serviceAccountName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/deploy/helm/sandbox/templates/web-deployment.yaml
+++ b/deploy/helm/sandbox/templates/web-deployment.yaml
@@ -1,10 +1,12 @@
 {{- if .Values.web.enabled }}
 ---
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "sandbox.webName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: web
@@ -29,7 +31,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "sandbox.webName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: web
@@ -38,7 +40,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: {{ index .Values.depServices "class-443" "ingressClass" | default "nginx" | quote }}
+  ingressClassName: {{ index $depServices "class-443" "ingressClass" | default "nginx" | quote }}
   rules:
   - http:
       paths:
@@ -58,7 +60,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "sandbox.webName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "sandbox.fullname" . }}
     component: web
@@ -90,14 +92,14 @@ spec:
             - sh
             - -c
             - |
-              until nc -z {{ include "sandbox.controlPlaneName" . }}.{{ .Values.namespace }}.svc.cluster.local {{ .Values.controlPlane.service.port }}; do
+              until nc -z {{ include "sandbox.controlPlaneName" . }}.{{ .Release.Namespace }}.svc.cluster.local {{ .Values.controlPlane.service.port }}; do
                 echo "Waiting for Control Plane..."
                 sleep 2
               done
               echo "Control Plane is ready!"
       containers:
         - name: web
-          image: "{{- if .Values.web.image.registry }}{{ .Values.web.image.registry }}/{{ else if .Values.image.registry }}{{ .Values.image.registry }}/{{ end }}{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
+          image: "{{- if .Values.web.image.registry }}{{ .Values.web.image.registry }}/{{ else if $imageRegistry }}{{ $imageRegistry }}/{{ end }}{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           # NOTE: DO NOT add VITE_API_BASE_URL environment variable here.
           # The frontend uses runtime URL detection via getApiBaseUrl()
@@ -135,4 +137,3 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
-


### PR DESCRIPTION
## Summary
- add umbrella-compatible helper functions for sandbox chart globals
- switch namespace-sensitive templates to release namespace and fix helper nil-safety
- wire the web/control-plane/minio/mariadb templates to shared global image and depServices values

## Test Plan
- helm template test ./deploy/helm/sandbox
- helm template test ./deploy/helm/sandbox --set global.image.registry=test.registry.com --set global.env.timezone=Asia/Shanghai --set global.env.language=en_US.UTF-8